### PR TITLE
Add edges

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install -r requirements.txt
         pip install cython wheel twine
     - name: Build
       run: |
@@ -65,6 +66,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install -r requirements.txt
         pip install cython wheel twine
     - name: Build
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         brew update
         brew install libomp
-        brew upgrade cmake
+        brew upgrade cmake || True
         brew reinstall gcc
     - name: Install dependencies
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,7 @@ if(NETWORKIT_PYTHON)
 	target_include_directories(_NetworKit BEFORE PUBLIC "${PROJECT_SOURCE_DIR}/include")
 	target_include_directories(_NetworKit PRIVATE "${PROJECT_SOURCE_DIR}/extlibs/ttmath/")
 	target_include_directories(_NetworKit PRIVATE "${NETWORKIT_PYTHON}")
+    target_include_directories(_NetworKit PUBLIC "${NUMPY_INCLUDE_DIR}")
 
 	if(NOT NETWORKIT_BUILD_CORE)
 		if(NOT EXTERNAL_NETWORKIT_CORE)

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -46,6 +46,14 @@ ctypedef index node
 ctypedef index cluster
 ctypedef double edgeweight
 
+
+import numpy as np
+
+# "cimport" is used to import special compile-time information
+# about the numpy module (this is stored in a file numpy.pxd which is
+# currently part of the Cython distribution).
+cimport numpy as np
+cimport cython
 cdef extern from "<networkit/Globals.hpp>" namespace "NetworKit":
 
 	index _none "NetworKit::none"
@@ -781,6 +789,17 @@ cdef class Graph:
 		"""
 		self._this.merge(G._this)
 		return self
+	
+	@cython.boundscheck(False) # turn off bounds-checking for entire function
+	@cython.wraparound(False)  # turn off negative index wrapping for entire function
+	def addEdges(self, np.ndarray[node, ndim=2] edge_list):
+		cdef Py_ssize_t num_edges = edge_list.shape[0]
+		cdef node n1
+		cdef node n2
+		for index in range(num_edges):
+			n1 = edge_list[index, 0]
+			n2 = edge_list[index, 1]
+			self._this.addEdge(n1, n2, 1.0)
 
 	def addEdge(self, u, v, w=1.0, addMissing = False):
 		""" Insert an undirected edge between the nodes `u` and `v`. If the graph is weighted you can optionally

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 seaborn
 sklearn
+numpy

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ def buildNetworKit(install_prefix, externalCore=False, withTests=False, rpath=No
 	comp_cmd.append("-DNETWORKIT_FLATINSTALL=ON")
 	from sysconfig import get_paths, get_config_var
 	comp_cmd.append("-DNETWORKIT_PYTHON="+get_paths()['include']) #provide python.h files
-	comp_cmd.append("-DNUMPY_INCLUDE_DIR="+numpy.get_include()) #provide python.h files
+	comp_cmd.append("-DNUMPY_INCLUDE_DIR="+numpy.get_include()) #provide numpy header files
 	comp_cmd.append("-DNETWORKIT_PYTHON_SOABI="+get_config_var('SOABI')) #provide lib env specification
 	if externalCore:
 		comp_cmd.append("-DNETWORKIT_BUILD_CORE=OFF")

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import shutil
 import sys
 import sysconfig
 import os
+import numpy
 
 cmakeCompiler = None
 buildDirectory = "build/build_python"
@@ -155,6 +156,7 @@ def buildNetworKit(install_prefix, externalCore=False, withTests=False, rpath=No
 	comp_cmd.append("-DNETWORKIT_FLATINSTALL=ON")
 	from sysconfig import get_paths, get_config_var
 	comp_cmd.append("-DNETWORKIT_PYTHON="+get_paths()['include']) #provide python.h files
+	comp_cmd.append("-DNUMPY_INCLUDE_DIR="+numpy.get_include()) #provide python.h files
 	comp_cmd.append("-DNETWORKIT_PYTHON_SOABI="+get_config_var('SOABI')) #provide lib env specification
 	if externalCore:
 		comp_cmd.append("-DNETWORKIT_BUILD_CORE=OFF")
@@ -215,7 +217,7 @@ class build_ext(Command):
 		self.build_lib = None # Output directory for libraries
 		self.build_temp = None # Temporary directory
 		self.inplace = False
-		self.include_dirs = None
+		#self.include_dirs = None
 		self.library_dirs = None
 		self.networkit_external_core = False
 		self.rpath = None

--- a/setup.py
+++ b/setup.py
@@ -217,7 +217,7 @@ class build_ext(Command):
 		self.build_lib = None # Output directory for libraries
 		self.build_temp = None # Temporary directory
 		self.inplace = False
-		#self.include_dirs = None
+		self.include_dirs = None
 		self.library_dirs = None
 		self.networkit_external_core = False
 		self.rpath = None

--- a/version.py
+++ b/version.py
@@ -1,6 +1,6 @@
 name='networkit'
 
-version='5.0'
+version='5.0.1'
 
 url='https://networkit.github.io/'
 


### PR DESCRIPTION
This PR adds a `addEdges` method to the python `Graph` class interface.
This makes adding edges ~5 times faster.
Using a python loop, inserting 10 Mio. edges take 3,5s.
Adding the same amount of edges in a cython loop takes 700ms.