### PR TITLE
Get mapping array

### DIFF
--- a/include/networkit/components/ConnectedComponents.hpp
+++ b/include/networkit/components/ConnectedComponents.hpp
@@ -76,6 +76,7 @@ public:
      * (i.e. re-numbered from 0 to n-1). If false, the node ids will not be changed.
      */
     static Graph extractLargestConnectedComponent(const Graph &G, bool compactGraph = false);
+    static node* get_raw_partition(const Graph &G);
 
 private:
     const Graph& G;

--- a/include/networkit/components/ConnectedComponents.hpp
+++ b/include/networkit/components/ConnectedComponents.hpp
@@ -17,6 +17,12 @@
 #include <networkit/base/Algorithm.hpp>
 
 namespace NetworKit {
+    struct cc_result {
+        node* components;
+        node n_nodes;
+        node* component_sizes;
+        node n_components;
+    };
 
 /**
  * @ingroup components
@@ -76,7 +82,7 @@ public:
      * (i.e. re-numbered from 0 to n-1). If false, the node ids will not be changed.
      */
     static Graph extractLargestConnectedComponent(const Graph &G, bool compactGraph = false);
-    static node* get_raw_partition(const Graph &G);
+    static cc_result get_raw_partition(const Graph &G);
 
 private:
     const Graph& G;

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -28,7 +28,7 @@ from libc.stdint cimport uint8_t
 # the C++ standard library
 from libcpp cimport bool as bool_t
 from libcpp.vector cimport vector
-from libcpp.utility cimport pair, tuple
+from libcpp.utility cimport pair
 from libcpp.map cimport map
 from libcpp.set cimport set
 from libcpp.stack cimport stack

--- a/networkit/_NetworKit.pyx
+++ b/networkit/_NetworKit.pyx
@@ -59,6 +59,11 @@ from cpython cimport PyObject, Py_INCREF
 # _always_ do that, or you will have segfaults
 np.import_array()
 
+# In order to transfer the ownership from C to python,
+# this class takes the C pointer and knows how to clean
+# up once the python object goes out of scope.
+# The wrapper code is taken from here: https://gist.github.com/GaelVaroquaux/1249305
+
 cdef class ArrayWrapper:
 	cdef void* data_ptr
 	cdef index size

--- a/networkit/cpp/components/ConnectedComponents.cpp
+++ b/networkit/cpp/components/ConnectedComponents.cpp
@@ -23,6 +23,11 @@ ConnectedComponents::ConnectedComponents(const Graph& G) : G(G) {
 }
 
 cc_result ConnectedComponents::get_raw_partition(const Graph & G) {
+    /*
+     * This is basically a copy from ConnectedComponents::run,
+     * but this function uses a raw c pointer to store the mapping_array
+     * instead of a std::vector. This enables the python interface to take ownership of the data and to avoid a copy.
+     */
     node n_components = 0;
     node max_id = G.upperNodeIdBound();
     auto mapping_array = new node[max_id];

--- a/networkit/cpp/components/ConnectedComponents.cpp
+++ b/networkit/cpp/components/ConnectedComponents.cpp
@@ -22,30 +22,33 @@ ConnectedComponents::ConnectedComponents(const Graph& G) : G(G) {
     }
 }
 
-node * ConnectedComponents::get_raw_partition(const Graph & G) {
+cc_result ConnectedComponents::get_raw_partition(const Graph & G) {
     node n_components = 0;
     node max_id = G.upperNodeIdBound();
-    auto array = new node[max_id];
+    auto mapping_array = new node[max_id];
 
-    std::fill_n(array, max_id, none);
+
+    std::fill_n(mapping_array, max_id, none);
+
+
     std::queue<node> q;
 
     // perform breadth-first searches
     G.forNodes([&](node u) {
-        if (array[u] == none) {
+        if (mapping_array[u] == none) {
             index c = n_components;
 
             q.push(u);
-            array[u] = c;
+            mapping_array[u] = c;
 
             do {
                 node u = q.front();
                 q.pop();
                 // enqueue neighbors, set array
                 G.forNeighborsOf(u, [&](node v) {
-                    if (array[v] == none) {
+                    if (mapping_array[v] == none) {
                         q.push(v);
-                        array[v] = c;
+                        mapping_array[v] = c;
                     }
                 });
             } while (!q.empty());
@@ -53,7 +56,15 @@ node * ConnectedComponents::get_raw_partition(const Graph & G) {
             ++n_components;
         }
     });
-    return array;
+
+    auto mapping_sizes = new node[n_components];
+    std::fill_n(mapping_sizes, n_components, 0);
+    for(node n = 0; n < max_id; ++n) {
+        ++mapping_sizes[mapping_array[n]];
+    }
+
+
+    return {mapping_array, max_id, mapping_sizes, n_components};
 }
 
 void ConnectedComponents::run() {

--- a/networkit/cpp/components/ConnectedComponents.cpp
+++ b/networkit/cpp/components/ConnectedComponents.cpp
@@ -7,6 +7,7 @@
 
 #include <set>
 #include <unordered_map>
+#include <algorithm>
 
 #include <networkit/auxiliary/Log.hpp>
 #include <networkit/components/ConnectedComponents.hpp>
@@ -19,6 +20,40 @@ ConnectedComponents::ConnectedComponents(const Graph& G) : G(G) {
     if (G.isDirected()) {
         throw std::runtime_error("Error, connected components of directed graphs cannot be computed, use StronglyConnectedComponents for them.");
     }
+}
+
+node * ConnectedComponents::get_raw_partition(const Graph & G) {
+    node n_components = 0;
+    node max_id = G.upperNodeIdBound();
+    auto array = new node[max_id];
+
+    std::fill_n(array, max_id, none);
+    std::queue<node> q;
+
+    // perform breadth-first searches
+    G.forNodes([&](node u) {
+        if (array[u] == none) {
+            index c = n_components;
+
+            q.push(u);
+            array[u] = c;
+
+            do {
+                node u = q.front();
+                q.pop();
+                // enqueue neighbors, set array
+                G.forNeighborsOf(u, [&](node v) {
+                    if (array[v] == none) {
+                        q.push(v);
+                        array[v] = c;
+                    }
+                });
+            } while (!q.empty());
+
+            ++n_components;
+        }
+    });
+    return array;
 }
 
 void ConnectedComponents::run() {

--- a/version.py
+++ b/version.py
@@ -1,6 +1,6 @@
 name='networkit'
 
-version='5.0.1'
+version='5.0.2'
 
 url='https://networkit.github.io/'
 


### PR DESCRIPTION
This PR adds a static method `get_raw_partition` to the `ConnectedComponents` class.
This method returns a raw pointer instead of an `std` container. This enables Cython to pass the ownership to python in order to avoid a copy.
