### PR TITLE
Manylinux

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -76,8 +76,11 @@ jobs:
           -w/app \
           quay.io/pypa/manylinux2010_x86_64 \
           bash -c "
-            \$PYBIN/python setup.py build_ext install
-            \$PYBIN/python setup.py sdist bdist_wheel -p manylinux2010_x86_64"
+            for PYBIN in /opt/python/*/bin; do
+              echo --> \$PYBIN
+              \$PYBIN/python setup.py build_ext install
+              \$PYBIN/python setup.py sdist bdist_wheel -p manylinux2010_x86_64
+            done"
     - name: Try to import on different python versions
       run: |
         docker run \

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -76,7 +76,8 @@ jobs:
           -w/app \
           quay.io/pypa/manylinux2010_x86_64 \
           bash -c "
-            for PYBIN in /opt/python/*/bin; do
+            set -e -x
+            for PYBIN in /opt/python/cp3*/bin; do
               echo '-->' \$PYBIN
               \$PYBIN/pip install cython
               \$PYBIN/python setup.py build_ext install
@@ -88,7 +89,8 @@ jobs:
           -v$(pwd):/app \
           quay.io/pypa/manylinux2010_x86_64 \
           bash -c "
-            for PYBIN in /opt/python/*/bin; do
+            set -e -x
+            for PYBIN in /opt/python/cp3*/bin; do
               echo '-->' \$PYBIN
               \$PYBIN/pip install /app/python/dist/*-py3-none-manylinux2010_x86_64.whl
               \$PYBIN/python -c 'import networkit; networkit.Graph(5)'

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['cp35-cp35m', 'cp36-cp36m', 'cp37-cp37m', 'cp38-cp38']
+        python-version: ['cp35-cp35m', 'cp36-cp36m', 'cp37-cp37m']
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.7]
 
     steps:
     - uses: actions/checkout@v1
@@ -66,18 +66,36 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install cython wheel twine
-    - name: Build
+    # - name: Build
+    #   run: |
+    #     python setup.py build_ext install
+    - name: Build with manylinux2010
       run: |
-        python setup.py build_ext install
+        docker run \
+          -v$(pwd):/app \
+          -w/app \
+          quay.io/pypa/manylinux2010_x86_64 \
+          bash -c "
+            \$PYBIN/python setup.py build_ext install
+            \$PYBIN/python setup.py sdist bdist_wheel -p manylinux2010_x86_64"
+    - name: Try to import on different python versions
+      run: |
+        docker run \
+          -v$(pwd):/app \
+          quay.io/pypa/manylinux2010_x86_64 \
+          bash -c "
+            for PYBIN in /opt/python/*/bin; do
+              echo --> \$PYBIN
+              \$PYBIN/pip install /app/python/dist/*-py3-none-manylinux2010_x86_64.whl
+              \$PYBIN/python -c 'import networkit; networkit.Graph(5)'
+              \$PYBIN/python -m unittest discover -v networkit/test/
+            done"
     - name: Smoke test
       run: |
         cd /tmp
         python -c "import networkit; networkit.Graph(5)"
     - name: Tests
       run: python -m unittest discover -v networkit/test/
-    - name: Build wheel
-      run: |
-        python setup.py build_ext sdist bdist_wheel
     - name: Publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -62,13 +62,7 @@ jobs:
         python-version: 3.7
     - name: Pull submodules
       run: git submodule update --init
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install cython wheel twine
-    # - name: Build
-    #   run: |
-    #     python setup.py build_ext install
+
     - name: Build with manylinux2010
       run: |
         docker run \
@@ -87,6 +81,7 @@ jobs:
             \$PYBIN/cython -3 --cplus -t networkit/_NetworKit.pyx
             \$PYBIN/python setup.py build_ext
             \$PYBIN/python setup.py sdist bdist_wheel -p manylinux2010_x86_64"
+
     - name: Test with manylinux2010
       run: |
         docker run \
@@ -101,9 +96,12 @@ jobs:
             \$PYBIN/pip install dist/*${{ matrix.python-version }}-manylinux2010_x86_64.whl
             \$PYBIN/python -c 'import networkit; networkit.Graph(5)'
             \$PYBIN/python -m unittest discover -v networkit/test/"
+
     - name: Publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
+        python -m pip install --upgrade pip
+        pip install twine
         twine upload --repository-url https://pypi.scm.io/simple dist/*.whl

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -86,7 +86,7 @@ jobs:
             \$PYBIN/pip install cython
             \$PYBIN/cython -3 --cplus -t networkit/_NetworKit.pyx
             \$PYBIN/python setup.py build_ext
-            \$PYBIN/python setup.py sdist bdist_wheel -p manylinux2010_x86_64
+            \$PYBIN/python setup.py sdist bdist_wheel -p manylinux2010_x86_64"
     - name: Test with manylinux2010
       run: |
         docker run \

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -42,6 +42,7 @@ jobs:
       run: |
         CC=gcc-9 python setup.py build_ext sdist bdist_wheel
     - name: Publish
+      if: github.ref == 'Dev'
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
@@ -99,6 +100,7 @@ jobs:
             \$PYBIN/python -m unittest discover -v networkit/test/"
 
     - name: Publish
+      if: github.ref == 'Dev'
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -52,14 +52,14 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7]
+        python-version: ['cp35-cp35m', 'cp36-cp36m', 'cp37-cp37m', 'cp38-cp38']
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.7
     - name: Pull submodules
       run: git submodule update --init
     - name: Install dependencies
@@ -74,35 +74,33 @@ jobs:
         docker run \
           -v$(pwd):/app \
           -w/app \
+          --rm \
+          -e PYBIN=/opt/python/${{ matrix.python-version }}/bin \
           quay.io/pypa/manylinux2010_x86_64 \
           bash -c "
             set -e -x
-            for PYBIN in /opt/python/cp3*/bin; do
-              echo '-->' \$PYBIN
-              \$PYBIN/pip install cython
-              \$PYBIN/cython -3 --cplus -t networkit/_NetworKit.pyx
-              \$PYBIN/python setup.py build_ext install
-              \$PYBIN/python setup.py sdist bdist_wheel -p manylinux2010_x86_64
-            done"
-    - name: Try to import on different python versions
+            yum remove cmake -y
+            yum install cmake3 -y
+            ln -s /usr/bin/cmake3 /usr/bin/cmake
+            echo '-->' \$PYBIN
+            \$PYBIN/pip install cython
+            \$PYBIN/cython -3 --cplus -t networkit/_NetworKit.pyx
+            \$PYBIN/python setup.py build_ext
+            \$PYBIN/python setup.py sdist bdist_wheel -p manylinux2010_x86_64
+    - name: Test with manylinux2010
       run: |
         docker run \
           -v$(pwd):/app \
+          -w/app \
+          --rm \
+          -e PYBIN=/opt/python/${{ matrix.python-version }}/bin \
           quay.io/pypa/manylinux2010_x86_64 \
           bash -c "
             set -e -x
-            for PYBIN in /opt/python/cp3*/bin; do
-              echo '-->' \$PYBIN
-              \$PYBIN/pip install /app/python/dist/*-py3-none-manylinux2010_x86_64.whl
-              \$PYBIN/python -c 'import networkit; networkit.Graph(5)'
-              \$PYBIN/python -m unittest discover -v networkit/test/
-            done"
-    - name: Smoke test
-      run: |
-        cd /tmp
-        python -c "import networkit; networkit.Graph(5)"
-    - name: Tests
-      run: python -m unittest discover -v networkit/test/
+            echo '-->' \$PYBIN
+            \$PYBIN/pip install dist/*${{ matrix.python-version }}-manylinux2010_x86_64.whl
+            \$PYBIN/python -c 'import networkit; networkit.Graph(5)'
+            \$PYBIN/python -m unittest discover -v networkit/test/"
     - name: Publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -79,6 +79,9 @@ jobs:
             yum install cmake3 -y
             ln -s /usr/bin/cmake3 /usr/bin/cmake
             echo '-->' \$PYBIN
+
+            \$PYBIN/python -m pip install --upgrade pip
+            \$PYBIN/pip install -r requirements.txt
             \$PYBIN/pip install cython
             \$PYBIN/cython -3 --cplus -t networkit/_NetworKit.pyx
             \$PYBIN/python setup.py build_ext

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -80,6 +80,7 @@ jobs:
             for PYBIN in /opt/python/cp3*/bin; do
               echo '-->' \$PYBIN
               \$PYBIN/pip install cython
+              \$PYBIN/cython -3 --cplus -t networkit/_NetworKit.pyx
               \$PYBIN/python setup.py build_ext install
               \$PYBIN/python setup.py sdist bdist_wheel -p manylinux2010_x86_64
             done"

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -77,7 +77,8 @@ jobs:
           quay.io/pypa/manylinux2010_x86_64 \
           bash -c "
             for PYBIN in /opt/python/*/bin; do
-              echo --> \$PYBIN
+              echo '-->' \$PYBIN
+              \$PYBIN/pip install cython
               \$PYBIN/python setup.py build_ext install
               \$PYBIN/python setup.py sdist bdist_wheel -p manylinux2010_x86_64
             done"
@@ -88,7 +89,7 @@ jobs:
           quay.io/pypa/manylinux2010_x86_64 \
           bash -c "
             for PYBIN in /opt/python/*/bin; do
-              echo --> \$PYBIN
+              echo '-->' \$PYBIN
               \$PYBIN/pip install /app/python/dist/*-py3-none-manylinux2010_x86_64.whl
               \$PYBIN/python -c 'import networkit; networkit.Graph(5)'
               \$PYBIN/python -m unittest discover -v networkit/test/

--- a/version.py
+++ b/version.py
@@ -1,6 +1,6 @@
 name='networkit'
 
-version='5.0.2'
+version='5.0.3'
 
 url='https://networkit.github.io/'
 


### PR DESCRIPTION
The current `5.0.2` networkit release does not work on some systems, producing `ImportError: /lib64/libm.so.6: version 'GLIBC_2.23' not found (required by /u/jonathan/conda-envs/segm-3.6_regressiontest/lib/python3.6/site-packages/libnetworkit.so)`.

We should
* merge the changes from this branch
* only push releases from the `Dev` branch
* bump the version.